### PR TITLE
Script using camera number as roll, not roll number

### DIFF
--- a/dm9toexif.pl
+++ b/dm9toexif.pl
@@ -102,7 +102,7 @@ for $dno (@ARGV){
 	# pre-fill pattern with roll-number
 	$pattern=$patternarg;
 	if($pattern =~ /\@R/){
-		if($dno =~ /(\d+)/){
+		if($dno =~ /\-0*(\d+)/){
 			$roll=$1;
 			$pattern =~ s/\@R/$roll/ge;
 		} else {

--- a/dn7toexif.pl
+++ b/dn7toexif.pl
@@ -88,7 +88,7 @@ for $dno (@ARGV){
 	# pre-fill pattern with roll-number
 	$pattern=$patternarg;
 	if($pattern =~ /\@R/){
-		if($dno =~ /(\d+)/){
+		if($dno =~ /\-0*(\d+)/){
 			$roll=$1;
 			$pattern =~ s/\@R/$roll/ge;
 		}


### PR DESCRIPTION
From the default filenames the ds-100 creates, the script is picking up the camera number, not the roll number, and using it as the roll.  This means it breaks as soon as it gets to roll 2.

```
...
fpat: dn1-0001_36
Modifying dn1-0001_36.tif into ../film-scans/dn1-0001_36.tif
Processing DN1-0002.TXT
DNO: DN1-0002.TXT
Roll: 1
Pattern: dn1-0001_@F

ISO found 400
fpat: dn1-0001_01
Modifying dn1-0001_01.tif into ../film-scans/dn1-0001_01.tif
fpat: dn1-0001_02
Modifying dn1-0001_02.tif into ../film-scans/dn1-0001_02.tif
fpat: dn1-0001_03
Modifying dn1-0001_03.tif into ../film-scans/dn1-0001_03.tif
^C
```

This fix adjusts the dno parsing regex to extract the roll number instead.

If this is just a Maxxum/Dynax 7 DS-100 issue, let me know and I can constrain the change to just the dn7 script.